### PR TITLE
Add autoconf to the management interface in IPv6

### DIFF
--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -920,7 +920,8 @@ class Data:
                         inPIF['opaqueref'], inPIF['ipv6_configuration_mode'], ','.join(inPIF['IPv6']), inPIF['ipv6_gateway'], FirstValue(inDNS, '')
                     )
             else:
-                inIPv6 = inIP + '/' + inNetmask
+                inIPv6 = '' if inIP == '0.0.0.0' else inIP + '/' + inNetmask
+                inGateway = '' if inGateway == '0.0.0.0' else inGateway
                 self.session.xenapi.PIF.reconfigure_ipv6(inPIF['opaqueref'],  inMode,  inIPv6,  inGateway, FirstValue(inDNS, ''))
                 if inPIF['ip_configuration_mode'].lower() == 'static':
                     # Update IPv4 DNS as well

--- a/plugins-base/XSFeatureInterface.py
+++ b/plugins-base/XSFeatureInterface.py
@@ -57,7 +57,8 @@ class InterfaceDialogue(Dialogue):
         if(currentPIF['primary_address_type'].lower() == 'ipv6'):
             mode_choicedefs.append(ChoiceDef(Lang("Autoconf"), lambda : self.HandleModeChoice("AUTOCONF") ))
         mode_choicedefs.append(ChoiceDef(Lang("DHCP"), lambda: self.HandleModeChoice('DHCP2') ))
-        mode_choicedefs.append(ChoiceDef(Lang("DHCP with Manually Assigned Hostname"), lambda: self.HandleModeChoice('DHCPMANUAL') ))
+        mode_choicedefs.append(ChoiceDef(Lang("DHCP with Manually Assigned Hostname"),
+                                         lambda: self.HandleModeChoice('DHCPMANUAL') ))
         mode_choicedefs.append(ChoiceDef(Lang("Static"), lambda: self.HandleModeChoice('STATIC') ))
         self.modeMenu = Menu(self, None, Lang("Select IP Address Configuration Mode"), mode_choicedefs)
 


### PR DESCRIPTION
Allows to configure the management interface in Autoconf when the interface primary type is IPv6.